### PR TITLE
Add generates_api to java_plugin rule

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -50,6 +50,7 @@ java_library(
 java_plugin(
     name = "dagger_plugin",
     processor_class = "dagger.internal.codegen.ComponentProcessor",
+    generates_api = True,
     deps = [
         ":dagger_api",
         ":dagger_compiler",


### PR DESCRIPTION
This is required for dagger to work with sources that are split across libraries (e.g. a framework as a java_library and a java_binary using it). 
See https://docs.bazel.build/versions/master/be/java.html#java_plugin